### PR TITLE
Refactor job page rendering logic

### DIFF
--- a/src/app/(web)/jobs/[...params]/page.tsx
+++ b/src/app/(web)/jobs/[...params]/page.tsx
@@ -3,7 +3,7 @@ import { searchJobs } from '@/data/jobs/search-jobs'
 import type { Job } from '@/data/types/job'
 import { capitalizeWords } from '@/utils/capitalize-words'
 import { isNumeric } from '@/utils/is-numeric'
-import { JobsTemplateDefault, SinglePageDefault } from '../../_templates/pages'
+import { SinglePageDefault } from '../../_templates/pages'
 
 let jobContent: JobContentOutput
 let jobs: Job[]
@@ -82,15 +82,5 @@ export default async function Page({
 		})
 	}
 
-	return (
-		<>
-			{isParamsId ? (
-				<SinglePageDefault content={jobContent} />
-			) : (
-				<JobsTemplateDefault title="Jobs">
-					<h1>Render JobList</h1>
-				</JobsTemplateDefault>
-			)}
-		</>
-	)
+	return <SinglePageDefault content={jobContent} />
 }


### PR DESCRIPTION
Remove unused `JobsTemplateDefault` and simplify the rendering logic for the job page. The code now directly uses `SinglePageDefault` for rendering.